### PR TITLE
Update YSF2P25.cpp

### DIFF
--- a/YSF2P25/YSF2P25.cpp
+++ b/YSF2P25/YSF2P25.cpp
@@ -388,6 +388,12 @@ int CYSF2P25::run()
 							break;
 
 						case WXS_DX:
+							if (!m_wiresX->getDstID()) {
+								sendP25PTT(m_srcid, 10U);
+								sendP25PTT(m_srcid, 9999U);
+							} else {
+								sendP25PTT(m_srcid, m_wiresX->getDstID());
+							}
 							break;
 
 						case WXS_DISCONNECT:


### PR DESCRIPTION
Helps to give voice feedback on connect.
Sending the PTT to TG10 (Parrot) and then TG9999 (Disconnect) forces the voice feedback on connect.

If there is already a link request in the WiresX connect, PTT to that TG, again makes the connection happen and provides voice feedback.