### PR TITLE
Multiple Patches

### DIFF
--- a/DMR2NXDN/Version.h
+++ b/DMR2NXDN/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20180809";
+const char* VERSION = "20200503";
 
 #endif

--- a/DMR2YSF/Version.h
+++ b/DMR2YSF/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20181008";
+const char* VERSION = "20200503";
 
 #endif

--- a/DMR2YSF/YSFFICH.cpp
+++ b/DMR2YSF/YSFFICH.cpp
@@ -232,6 +232,12 @@ void CYSFFICH::setCS(unsigned char cs)
 	m_fich[0U] |= (cs << 4) & 0x30U;
 }
 
+void CYSFFICH::setCM(unsigned char cm)
+{
+	m_fich[0U] &= 0xF3U;
+	m_fich[0U] |= (cm << 2) & 0x0CU;
+}
+
 void CYSFFICH::setFN(unsigned char fn)
 {
 	m_fich[1U] &= 0xC7U;

--- a/DMR2YSF/YSFFICH.h
+++ b/DMR2YSF/YSFFICH.h
@@ -44,6 +44,7 @@ public:
 
 	void setFI(unsigned char fi);
 	void setCS(unsigned char cs);
+	void setCM(unsigned char cm);
 	void setFN(unsigned char fn);
 	void setFT(unsigned char ft);
 	void setBN(unsigned char bn);

--- a/NXDN2DMR/Version.h
+++ b/NXDN2DMR/Version.h
@@ -20,6 +20,7 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20180923";
+const char* VERSION = "20200503";
 
 #endif
+

--- a/YSF2DMR/Version.h
+++ b/YSF2DMR/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20190204";
+const char* VERSION = "20200503";
 
 #endif

--- a/YSF2DMR/WiresX.cpp
+++ b/YSF2DMR/WiresX.cpp
@@ -635,9 +635,10 @@ void CWiresX::sendDXReply()
 		sprintf(buf, "%05d", m_dstID);
 		::memcpy(data + 36U, buf, 5U);
 		
-		if (m_dstID > 99999U)
-			sprintf(buf1, "CALL %d", m_dstID);
-		else if (m_dstID == 9U)
+		//if (m_dstID > 99999U)
+		//	sprintf(buf1, "CALL %d", m_dstID);
+		//else if (m_dstID == 9U)
+		if (m_dstID == 9U)
 			strcpy(buf1, "LOCAL");
 		else if (m_dstID == 9990U)
 			strcpy(buf1, "PARROT");
@@ -721,9 +722,10 @@ void CWiresX::sendConnectReply(unsigned int dstID)
 	sprintf(buf, "%05d", m_dstID);
 	::memcpy(data + 36U, buf, 5U);
 
-	if (m_dstID > 99999U)
-		sprintf(buf1, "CALL %d", m_dstID);
-	else if (m_dstID == 9U)
+	//if (m_dstID > 99999U)
+	//	sprintf(buf1, "CALL %d", m_dstID);
+	//else if (m_dstID == 9U)
+	if (m_dstID == 9U)
 		strcpy(buf1, "LOCAL");
 	else if (m_dstID == 9990U)
 		strcpy(buf1, "PARROT");

--- a/YSF2DMR/YSF2DMR.cpp
+++ b/YSF2DMR/YSF2DMR.cpp
@@ -33,6 +33,7 @@
 // DT1 and DT2, suggested by Manuel EA7EE
 const unsigned char dt1_temp[] = {0x31, 0x22, 0x62, 0x5F, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00};
 const unsigned char dt2_temp[] = {0x00, 0x00, 0x00, 0x00, 0x6C, 0x20, 0x1C, 0x20, 0x03, 0x08};
+const uint8_t dt1[10] = {0x01, 0x22, 0x61, 0x5f, 0x2b, 0x03, 0x11, 0x00, 0x00, 0x00};
 
 #define DMR_FRAME_PER       55U
 #define YSF_FRAME_PER       90U
@@ -50,6 +51,7 @@ const char* HEADER1 = "This software is for use on amateur radio networks only,"
 const char* HEADER2 = "it is to be used for educational purposes only. Its use on";
 const char* HEADER3 = "commercial networks is strictly prohibited.";
 const char* HEADER4 = "Copyright(C) 2018,2019 by CA6JAU, EA7EE, G4KLX and others";
+const char ysf_radioid[] = {'H', '5', '0', '0', '0'};
 
 #include <functional>
 #include <algorithm>
@@ -942,13 +944,17 @@ int CYSF2DMR::run()
 				CYSFFICH fich;
 				fich.setFI(YSF_FI_HEADER);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(0U);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
+				fich.setMR(0U);
+ 				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VD_MODE2);
 				fich.setSQL(false);
 				fich.setSQ(0U);
-				fich.setMR(2U);
 
 				if (m_remoteGateway) {
 					fich.setVoIP(false);
@@ -961,7 +967,8 @@ int CYSF2DMR::run()
 				fich.encode(m_ysfFrame + 35U);
 
 				unsigned char csd1[20U], csd2[20U];
-				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
+				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
+ 				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
 				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_netSrc.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
@@ -986,13 +993,17 @@ int CYSF2DMR::run()
 				CYSFFICH fich;
 				fich.setFI(YSF_FI_TERMINATOR);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(0U);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
+				fich.setMR(0U);
+ 				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VD_MODE2);
 				fich.setSQL(false);
 				fich.setSQ(0U);
-				fich.setMR(2U);
 
 				if (m_remoteGateway) {
 					fich.setVoIP(false);
@@ -1005,7 +1016,8 @@ int CYSF2DMR::run()
 				fich.encode(m_ysfFrame + 35U);
 
 				unsigned char csd1[20U], csd2[20U];
-				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
+				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
+ 				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
 				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_netSrc.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
@@ -1017,8 +1029,9 @@ int CYSF2DMR::run()
 			else if (ysfFrameType == TAG_DATA) {
 				CYSFFICH fich;
 				CYSFPayload ysfPayload;
+				unsigned char dch[10U];
 
-				unsigned int fn = (ysf_cnt - 1U) % 8U;
+				unsigned int fn = (ysf_cnt - 1U) % 7U;
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_ysfNetwork->getCallsign().c_str(), YSF_CALLSIGN_LENGTH);
@@ -1030,7 +1043,9 @@ int CYSF2DMR::run()
 
 				switch (fn) {
 					case 0:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)"**********");
+						memset(dch, '*', YSF_CALLSIGN_LENGTH/2);
+ 						memcpy(dch + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
+ 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dch);
 						break;
 					case 1:
 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)m_netSrc.c_str());
@@ -1038,11 +1053,16 @@ int CYSF2DMR::run()
 					case 2:
 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)m_netDst.c_str());
 						break;
+					case 5:
+ 						memset(dch, ' ', YSF_CALLSIGN_LENGTH/2);
+ 						memcpy(dch + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
+ 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dch);	// Rem3/4
+ 						break;
 					case 6:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, gps_buffer);
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dt1);
 						break;
 					case 7:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, gps_buffer+10U);
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dt2_temp);
 						break;
 					default:
 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)"          ");
@@ -1051,9 +1071,14 @@ int CYSF2DMR::run()
 				// Set the FICH
 				fich.setFI(YSF_FI_COMMUNICATIONS);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(fn);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
+				fich.setMR(0U);
+ 				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VD_MODE2);
 				fich.setSQL(false);
 				fich.setSQ(0U);

--- a/YSF2NXDN/Version.h
+++ b/YSF2NXDN/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20190204";
+const char* VERSION = "20200503";
 
 #endif

--- a/YSF2NXDN/YSF2NXDN.cpp
+++ b/YSF2NXDN/YSF2NXDN.cpp
@@ -546,8 +546,8 @@ int CYSF2NXDN::run()
 
 						m_netSrc = m_lookup->findCS(srcId);
 						//m_netDst = m_lookup->findCS(dstId);
-						if (srcId != 9999U) { m_netDst = m_lookup->findCS(dstId); } else { m_netDst = std::to_string(dstId); }
-						LogMessage("Received NXDN Header: Src: %s Dst: %s", m_netSrc.c_str(), m_netDst.c_str());
+						m_netDst = "TG " + std::to_string(dstId);
+                                                LogMessage("Received NXDN Header: Src: %s Dst: %s", m_netSrc.c_str(), m_netDst.c_str());
 
 						m_conv.putNXDNHeader();
 						m_nxdnFrames = 0;

--- a/YSF2NXDN/YSF2NXDN.cpp
+++ b/YSF2NXDN/YSF2NXDN.cpp
@@ -33,6 +33,7 @@
 // DT1 and DT2, suggested by Manuel EA7EE
 const unsigned char dt1_temp[] = {0x31, 0x22, 0x62, 0x5F, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00};
 const unsigned char dt2_temp[] = {0x00, 0x00, 0x00, 0x00, 0x6C, 0x20, 0x1C, 0x20, 0x03, 0x08};
+const uint8_t dt1[10] = {0x01, 0x22, 0x61, 0x5f, 0x2b, 0x03, 0x11, 0x00, 0x00, 0x00};
 
 #define NXDN_FRAME_PER      75U
 #define YSF_FRAME_PER       90U
@@ -47,6 +48,7 @@ const char* HEADER1 = "This software is for use on amateur radio networks only,"
 const char* HEADER2 = "it is to be used for educational purposes only. Its use on";
 const char* HEADER3 = "commercial networks is strictly prohibited.";
 const char* HEADER4 = "Copyright(C) 2018,2019 by CA6JAU, G4KLX and others";
+const char ysf_radioid[] = {'H', '5', '0', '0', '0'};
 
 #include <functional>
 #include <algorithm>
@@ -605,17 +607,23 @@ int CYSF2NXDN::run()
 				CYSFFICH fich;
 				fich.setFI(YSF_FI_HEADER);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(0U);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
-				fich.setMR(2U);
+				fich.setMR(0U);
+				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VD_MODE2);
 				fich.setSQL(0U);
 				fich.setSQ(0U);
 				fich.encode(m_ysfFrame + 35U);
 
 				unsigned char csd1[20U], csd2[20U];
-				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
+				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
+				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
+				//memset(csd1, '*', YSF_CALLSIGN_LENGTH);
 				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_netSrc.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
@@ -623,7 +631,7 @@ int CYSF2NXDN::run()
 				payload.writeHeader(m_ysfFrame + 35U, csd1, csd2);
 
 				m_ysfNetwork->write(m_ysfFrame);
-				
+
 				ysf_cnt++;
 				ysfWatch.start();
 			}
@@ -640,17 +648,23 @@ int CYSF2NXDN::run()
 				CYSFFICH fich;
 				fich.setFI(YSF_FI_TERMINATOR);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(0U);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
-				fich.setMR(2U);
+				fich.setMR(0U);
+				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VD_MODE2);
 				fich.setSQL(0U);
 				fich.setSQ(0U);
 				fich.encode(m_ysfFrame + 35U);
 
 				unsigned char csd1[20U], csd2[20U];
-				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
+				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
+ 				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
+				//memset(csd1, '*', YSF_CALLSIGN_LENGTH);
 				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_netSrc.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
@@ -662,8 +676,9 @@ int CYSF2NXDN::run()
 			else if (ysfFrameType == TAG_DATA) {
 				CYSFFICH fich;
 				CYSFPayload ysfPayload;
+				unsigned char dch[10U];
 
-				unsigned int fn = (ysf_cnt - 1U) % 8U;
+				unsigned int fn = (ysf_cnt - 1U) % 7U;
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_ysfNetwork->getCallsign().c_str(), YSF_CALLSIGN_LENGTH);
@@ -675,7 +690,10 @@ int CYSF2NXDN::run()
 
 				switch (fn) {
 					case 0:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)"**********");
+						memset(dch, '*', YSF_CALLSIGN_LENGTH/2);
+ 						memcpy(dch + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
+ 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dch);
+						//ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)"**********");
 						break;
 					case 1:
 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)m_netSrc.c_str());
@@ -683,11 +701,16 @@ int CYSF2NXDN::run()
 					case 2:
 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)m_netDst.c_str());
 						break;
+					case 5:
+ 						memset(dch, ' ', YSF_CALLSIGN_LENGTH/2);
+ 						memcpy(dch + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
+ 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dch);	// Rem3/4
+ 						break;
 					case 6:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, gps_buffer);
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dt1);
 						break;
 					case 7:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, gps_buffer + 10U);
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dt2_temp);
 						break;
 					default:
 						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (const unsigned char*)"          ");
@@ -696,10 +719,14 @@ int CYSF2NXDN::run()
 				// Set the FICH
 				fich.setFI(YSF_FI_COMMUNICATIONS);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(fn);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
-				fich.setMR(YSF_MR_BUSY);
+				fich.setMR(0U);
+				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VD_MODE2);
 				fich.setSQL(0U);
 				fich.setSQ(0U);

--- a/YSF2NXDN/YSF2NXDN.cpp
+++ b/YSF2NXDN/YSF2NXDN.cpp
@@ -545,7 +545,8 @@ int CYSF2NXDN::run()
 						::memcpy(gps_buffer + 10U, dt2_temp, 10U);
 
 						m_netSrc = m_lookup->findCS(srcId);
-						m_netDst = m_lookup->findCS(dstId);
+						//m_netDst = m_lookup->findCS(dstId);
+						if (srcId != 9999U) { m_netDst = m_lookup->findCS(dstId); } else { m_netDst = std::to_string(dstId); }
 						LogMessage("Received NXDN Header: Src: %s Dst: %s", m_netSrc.c_str(), m_netDst.c_str());
 
 						m_conv.putNXDNHeader();

--- a/YSF2NXDN/YSFFICH.cpp
+++ b/YSF2NXDN/YSFFICH.cpp
@@ -232,6 +232,12 @@ void CYSFFICH::setCS(unsigned char cs)
 	m_fich[0U] |= (cs << 4) & 0x30U;
 }
 
+void CYSFFICH::setCM(unsigned char cm)
+{
+	m_fich[0U] &= 0xF3U;
+	m_fich[0U] |= (cm << 2) & 0x0CU;
+}
+
 void CYSFFICH::setFN(unsigned char fn)
 {
 	m_fich[1U] &= 0xC7U;

--- a/YSF2NXDN/YSFFICH.h
+++ b/YSF2NXDN/YSFFICH.h
@@ -44,6 +44,7 @@ public:
 
 	void setFI(unsigned char fi);
 	void setCS(unsigned char cs);
+	void setCM(unsigned char cm);
 	void setFN(unsigned char fn);
 	void setFT(unsigned char ft);
 	void setBN(unsigned char bn);

--- a/YSF2P25/Version.h
+++ b/YSF2P25/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20190204";
+const char* VERSION = "20200503";
 
 #endif

--- a/YSF2P25/YSF2P25.cpp
+++ b/YSF2P25/YSF2P25.cpp
@@ -92,6 +92,8 @@ const unsigned char REC73[] = {
 const unsigned char REC80[] = {
 	0x80U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U};
 
+const uint8_t dt1[10] = {0x01, 0x22, 0x61, 0x5f, 0x2b, 0x03, 0x11, 0x00, 0x00, 0x00};
+
 #define P25_FRAME_PER       15U
 #define YSF_FRAME_PER       90U
 
@@ -105,6 +107,7 @@ const char* HEADER1 = "This software is for use on amateur radio networks only,"
 const char* HEADER2 = "it is to be used for educational purposes only. Its use on";
 const char* HEADER3 = "commercial networks is strictly prohibited.";
 const char* HEADER4 = "Copyright(C) 2018,2019 by CA6JAU, G4KLX and others";
+const char ysf_radioid[] = {'H', '5', '0', '0', '0'};
 
 #include <functional>
 #include <algorithm>
@@ -621,17 +624,22 @@ int CYSF2P25::run()
 				CYSFFICH fich;
 				fich.setFI(YSF_FI_HEADER);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(0U);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
-				fich.setMR(2U);
+				fich.setMR(0U);
+				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VOICE_FR_MODE);
 				fich.setSQL(0U);
 				fich.setSQ(0U);
 				fich.encode(m_ysfFrame + 35U);
 
 				unsigned char csd1[20U], csd2[20U];
-				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
+				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
+ 				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
 				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_netSrc.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
@@ -656,17 +664,22 @@ int CYSF2P25::run()
 				CYSFFICH fich;
 				fich.setFI(YSF_FI_TERMINATOR);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(0U);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
-				fich.setMR(2U);
+				fich.setMR(0U);
+				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VOICE_FR_MODE);
 				fich.setSQL(0U);
 				fich.setSQ(0U);
 				fich.encode(m_ysfFrame + 35U);
 
 				unsigned char csd1[20U], csd2[20U];
-				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
+				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
+ 				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, ysf_radioid, YSF_CALLSIGN_LENGTH/2);
 				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_netSrc.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
@@ -679,8 +692,8 @@ int CYSF2P25::run()
 			else if (ysfFrameType == TAG_DATA) {
 				CYSFFICH fich;
 				CYSFPayload ysfPayload;
-
-				unsigned int fn = (ysf_cnt - 1U) % 1U;
+				//unsigned char dch[10U];
+				unsigned int fn = (ysf_cnt - 1U) % 7U;
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_ysfNetwork->getCallsign().c_str(), YSF_CALLSIGN_LENGTH);
@@ -693,10 +706,14 @@ int CYSF2P25::run()
 				// Set the FICH
 				fich.setFI(YSF_FI_COMMUNICATIONS);
 				fich.setCS(2U);
+				fich.setCM(1U);
+ 				fich.setBN(0U);
+ 				fich.setBT(0U);
 				fich.setFN(fn);
-				fich.setFT(7U);
+				fich.setFT(6U);
 				fich.setDev(0U);
-				fich.setMR(YSF_MR_BUSY);
+				fich.setMR(0U);
+				fich.setVoIP(false);
 				fich.setDT(YSF_DT_VOICE_FR_MODE);
 				fich.setSQL(0U);
 				fich.setSQ(0U);

--- a/YSF2P25/YSFFICH.cpp
+++ b/YSF2P25/YSFFICH.cpp
@@ -232,6 +232,12 @@ void CYSFFICH::setCS(unsigned char cs)
 	m_fich[0U] |= (cs << 4) & 0x30U;
 }
 
+void CYSFFICH::setCM(unsigned char cm)
+{
+	m_fich[0U] &= 0xF3U;
+	m_fich[0U] |= (cm << 2) & 0x0CU;
+}
+
 void CYSFFICH::setFN(unsigned char fn)
 {
 	m_fich[1U] &= 0xC7U;

--- a/YSF2P25/YSFFICH.h
+++ b/YSF2P25/YSFFICH.h
@@ -44,6 +44,7 @@ public:
 
 	void setFI(unsigned char fi);
 	void setCS(unsigned char cs);
+	void setCM(unsigned char cm);
 	void setFN(unsigned char fn);
 	void setFT(unsigned char ft);
 	void setBN(unsigned char bn);


### PR DESCRIPTION
This PR consists of a number of patches;

1. YSF2NXDN - patched to stop it from looking up target TG numbers in the NXDN user database.
This was causing traffic bound for a TG to show as being directed to a user on the Yaesu Radio screen.

2. Patches for DMR2YSF, YSF2DMR, YSF2NXDN, YSF2P25 to address issues with newer radios getting silence back from connected reflectors.

3. bumped version numbers etc.