### PR TITLE
Fix: Callsigns transmitted and formatted correctly for USRP2YSF and M172YSF

### DIFF
--- a/M172YSF/M172YSF.cpp
+++ b/M172YSF/M172YSF.cpp
@@ -36,7 +36,7 @@ const char* DEFAULT_INI_FILE = "/etc/M172DMR.ini";
 const char* HEADER1 = "This software is for use on amateur radio networks only,";
 const char* HEADER2 = "it is to be used for educational purposes only. Its use on";
 const char* HEADER3 = "commercial networks is strictly prohibited.";
-const char* HEADER4 = "Copyright(C) 2018 by AD8DP, CA6JAU, G4KLX and others";
+const char* HEADER4 = "Copyright(C) 2022 by AC8ZD, AD8DP, CA6JAU, G4KLX and others";
 
 #define M17CHARACTERS " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/."
 

--- a/M172YSF/M172YSF.cpp
+++ b/M172YSF/M172YSF.cpp
@@ -2,6 +2,7 @@
 *   Copyright (C) 2016,2017 by Jonathan Naylor G4KLX
 *   Copyright (C) 2018 by Andy Uribe CA6JAU
 * 	Copyright (C) 2020 by Doug McLain AD8DP
+* 	Copyright (C) 2022 by Dave Behnke AC8ZD
 *
 *   This program is free software; you can redistribute it and/or modify
 *   it under the terms of the GNU General Public License as published by
@@ -97,6 +98,26 @@ void decode_callsign(uint8_t *callsign)
 	}
 }
 
+//trim is necessary over usrp, especially USRP2M17, since people put wonky
+//calls in their radio like AC8ZD/DAVE. By default, callsigns coming in from YSF
+//are 10 characters and padded with spaces if callsign isn't that long.
+//to make it extra M17 friendly, we ensure the callsign is no longer than 8 characters.
+std::string trim_callsign(const std::string s) {
+    const std::string ACCEPTABLECHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    size_t start = s.find_first_not_of(ACCEPTABLECHARS);
+    if (start > 8) {
+        start = 8;
+    }
+    return s.substr(0, start);
+}
+
+//pad is necessary for the reverse back to ysf, the callsign needs to be 10 characters
+//spaces need to be placed if all 10 characters not used.
+void pad_callsign(std::string &str, const size_t num, const char paddingChar = ' ')
+{
+    if(num > str.size())
+        str.insert(str.size(), num - str.size(), paddingChar);
+}
 
 int main(int argc, char** argv)
 {
@@ -337,6 +358,7 @@ int CM172YSF::run()
 				else if (m_m17Frame[34U] & 0x80U) {
 					LogMessage("M17 received end of voice transmission, %.1f seconds", float(m_m17Frames) / 25.0F);
 					m_conv.putM17EOT();
+					m_m17cs.clear();
 				}
 				else{
 					m_conv.putM17(m_m17Frame);
@@ -346,6 +368,8 @@ int CM172YSF::run()
 				decode_callsign(cs);
 				std::string css((char *)cs);
 				css = css.substr(0, css.find(' '));
+				pad_callsign(css, 10, ' ');
+				m_m17cs = css;
 				m_m17Frames++;
 			}
 		}
@@ -368,10 +392,12 @@ int CM172YSF::run()
 
 						if (fi == YSF_FI_HEADER) {
 							if (ysfPayload.processHeaderData(buffer + 35U)) {
-								std::string ysfSrc = ysfPayload.getSource();
+								std::string ysfSrcRaw = ysfPayload.getSource();
+								std::string ysfSrc = trim_callsign(ysfSrcRaw);
 								std::string ysfDst = ysfPayload.getDest();
 								LogMessage("Received YSF Header: Src: %s Dst: %s", ysfSrc.c_str(), ysfDst.c_str());
 								m_conv.putYSFHeader();
+								m_ysfcs = ysfSrc;
 							}
 						} else if (fi == YSF_FI_TERMINATOR) {
 							LogMessage("YSF received end of voice transmission");
@@ -385,8 +411,21 @@ int CM172YSF::run()
 		}
 
 		if (m17Watch.elapsed() > M17_FRAME_PER) {
-			unsigned int m17FrameType = m_conv.getM17(m_m17Frame);
+			uint32_t m17FrameType = m_conv.getM17(m_m17Frame);
 			
+			if( (m_ysfcs.size()) > 3 && (m_ysfcs.size() < 8) ){
+				memset(m17_src, ' ', 9);
+				memcpy(m17_src, m_ysfcs.c_str(), m_ysfcs.size());
+				m17_src[8] = 'D';
+				m17_src[9] = 0x00;
+				encode_callsign(m17_src);
+			}
+			else{
+				memcpy(m17_src, m_callsign.c_str(), 9);
+				m17_src[9] = 0x00;
+				encode_callsign(m17_src);
+			}
+
 			if(m17FrameType == TAG_HEADER) {
 				m17_cnt = 0U;
 				m17Watch.start();
@@ -443,7 +482,7 @@ int CM172YSF::run()
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
-				::memcpy(m_ysfFrame + 14U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 14U, m_m17cs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = 0U; // Net frame counter
 
@@ -470,7 +509,7 @@ int CM172YSF::run()
 				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
  				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
  				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, m_conf.getYsfRadioID().c_str(), YSF_CALLSIGN_LENGTH/2);
-				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_m17cs.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
 				CYSFPayload payload;
@@ -485,7 +524,7 @@ int CM172YSF::run()
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
-				::memcpy(m_ysfFrame + 14U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 14U, m_m17cs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = ysf_cnt; // Net frame counter
 
@@ -511,7 +550,7 @@ int CM172YSF::run()
 				unsigned char csd1[20U], csd2[20U];
 				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
  				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, m_conf.getYsfRadioID().c_str(), YSF_CALLSIGN_LENGTH/2);
-				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_m17cs.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
 				CYSFPayload payload;
@@ -529,7 +568,7 @@ int CM172YSF::run()
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
-				::memcpy(m_ysfFrame + 14U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 14U, m_m17cs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 
 				::memcpy(m_ysfFrame + 35U, YSF_SYNC_BYTES, YSF_SYNC_LENGTH_BYTES);
@@ -541,10 +580,10 @@ int CM172YSF::run()
  						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dch);
 						break;
 					case 1:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_callsign.c_str());
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_m17cs.c_str());
 						break;
 					case 2:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_callsign.c_str());
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_m17cs.c_str());
 						break;
 					case 5:
 						memset(dch, ' ', YSF_CALLSIGN_LENGTH/2);

--- a/M172YSF/M172YSF.cpp
+++ b/M172YSF/M172YSF.cpp
@@ -395,7 +395,7 @@ int CM172YSF::run()
 								std::string ysfSrcRaw = ysfPayload.getSource();
 								std::string ysfSrc = trim_callsign(ysfSrcRaw);
 								std::string ysfDst = ysfPayload.getDest();
-								LogMessage("Received YSF Header: Src: %s Dst: %s", ysfSrc.c_str(), ysfDst.c_str());
+								LogMessage("Received YSF Header: Raw Src: \"%s\" Src: \"%s\" Dst: \"%s\"", ysfSrcRaw.c_str(), ysfSrc.c_str(), ysfDst.c_str());
 								m_conv.putYSFHeader();
 								m_ysfcs = ysfSrc;
 							}

--- a/M172YSF/M172YSF.h
+++ b/M172YSF/M172YSF.h
@@ -47,7 +47,9 @@ public:
 
 private:
 	std::string      m_callsign;
-	std::string		 m_m17Ref;
+	std::string      m_ysfcs;
+	std::string 	 m_m17cs;
+	std::string 	 m_m17Ref;
 	CConf            m_conf;
 	CYSFNetwork*     m_ysfNetwork;
 	CM17Network*	 m_m17Network;

--- a/M172YSF/Version.h
+++ b/M172YSF/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20180923";
+const char* VERSION = "20221013";
 
 #endif

--- a/USRP2M17/USRP2M17.cpp
+++ b/USRP2M17/USRP2M17.cpp
@@ -318,6 +318,7 @@ int CUSRP2M17::run()
 			uint32_t m17FrameType = m_conv.getM17(m_m17Frame);
 			
 			if( (m_usrpcs.size()) > 3 && (m_usrpcs.size() < 8) ){
+				LogMessage("debug: encoding usrpcs: %s", m_usrpcs.c_str());
 				memset(m17_src, ' ', 9);
 				memcpy(m17_src, m_usrpcs.c_str(), m_usrpcs.size());
 				m17_src[8] = 'D';
@@ -325,6 +326,7 @@ int CUSRP2M17::run()
 				encode_callsign(m17_src);
 			}
 			else{
+				LogMessage("debug: encoding m_callsign: %s", m_callsign.c_str());
 				memcpy(m17_src, m_callsign.c_str(), 9);
 				m17_src[9] = 0x00;
 				encode_callsign(m17_src);

--- a/USRP2M17/USRP2M17.cpp
+++ b/USRP2M17/USRP2M17.cpp
@@ -487,7 +487,7 @@ int CUSRP2M17::run()
 					
 					if(!m_usrpFrames){	
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received first frame, callsign=%s", m_usrpcs);
+						LogMessage("USRP text info received first frame, callsign=%s", m_usrpcs.c_str());
 					}
 					m_usrpFrames++;
 				}

--- a/USRP2M17/USRP2M17.cpp
+++ b/USRP2M17/USRP2M17.cpp
@@ -487,7 +487,7 @@ int CUSRP2M17::run()
 					
 					if(!m_usrpFrames){	
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received as first frame");
+						LogMessage("USRP text info received first frame, callsign=%s", m_usrpcs);
 					}
 					m_usrpFrames++;
 				}

--- a/USRP2M17/USRP2M17.cpp
+++ b/USRP2M17/USRP2M17.cpp
@@ -318,7 +318,6 @@ int CUSRP2M17::run()
 			uint32_t m17FrameType = m_conv.getM17(m_m17Frame);
 			
 			if( (m_usrpcs.size()) > 3 && (m_usrpcs.size() < 8) ){
-				LogMessage("debug: encoding usrpcs: %s", m_usrpcs.c_str());
 				memset(m17_src, ' ', 9);
 				memcpy(m17_src, m_usrpcs.c_str(), m_usrpcs.size());
 				m17_src[8] = 'D';
@@ -326,7 +325,6 @@ int CUSRP2M17::run()
 				encode_callsign(m17_src);
 			}
 			else{
-				LogMessage("debug: encoding m_callsign: %s", m_callsign.c_str());
 				memcpy(m17_src, m_callsign.c_str(), 9);
 				m17_src[9] = 0x00;
 				encode_callsign(m17_src);
@@ -489,7 +487,7 @@ int CUSRP2M17::run()
 					
 					if(!m_usrpFrames){	
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received first frame, callsign=%s", m_usrpcs.c_str());
+						LogMessage("USRP text info received first frame, callsign=%s (%d bytes)", m_usrpcs.c_str(), m_usrpcs.size());
 					}
 					m_usrpFrames++;
 				}

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -434,7 +434,7 @@ int CUSRP2YSF::run()
 				memset(csd1, '*', YSF_CALLSIGN_LENGTH);
  				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
  				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, m_conf.getYsfRadioID().c_str(), YSF_CALLSIGN_LENGTH/2);
-				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
 				CYSFPayload payload;

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -406,7 +406,7 @@ int CUSRP2YSF::run()
 				ysf_cnt = 0U;
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
-				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 4U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = 0U; // Net frame counter
@@ -448,7 +448,7 @@ int CUSRP2YSF::run()
 			else if (ysfFrameType == TAG_EOT) {
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
-				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 4U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = ysf_cnt; // Net frame counter
@@ -492,7 +492,7 @@ int CUSRP2YSF::run()
 				unsigned int fn = (ysf_cnt - 1U) % (m_conf.getFICHFrameTotal() + 1);
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
-				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 4U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -266,12 +266,11 @@ int CUSRP2YSF::run()
 
 			if( (!memcmp(m_usrpFrame, "USRP", 4)) && len == 352) {
 				if( (m_usrpFrame[20] == USRP_TYPE_TEXT) && (m_usrpFrame[32] == TLV_TAG_SET_INFO) ){
-					std::string raw_usrpcs = (char *)(m_usrpFrame + 46);
-					m_usrpcs = trim_callsign(raw_usrpcs);
+					m_usrpcs = (char *)(m_usrpFrame + 46);
 					if (!m_usrpFrames)
 					{
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received as first frame raw_callsign=%s, trim_callsign=%s", raw_usrpcs.c_str(), m_usrpcs.c_str());
+						LogMessage("USRP text info received as first frame callsign=%s", m_usrpcs.c_str());
 					}
 					m_usrpFrames++;
 				}
@@ -309,9 +308,10 @@ int CUSRP2YSF::run()
 
 						if (fi == YSF_FI_HEADER) {
 							if (ysfPayload.processHeaderData(buffer + 35U)) {
-								std::string ysfSrc = ysfPayload.getSource();
+								std::string ysfSrcRaw = ysfPayload.getSource();
+								std::string ysfSrc = trim_callsign(ysfSrcRaw);
 								std::string ysfDst = ysfPayload.getDest();
-								LogMessage("Received YSF Header: Src: %s Dst: %s", ysfSrc.c_str(), ysfDst.c_str());
+								LogMessage("Received YSF Header: RawSrc: \"%s\" Src: \"%s\" Dst: \"%s\"", ysfSrcRaw.c_str(), ysfSrc.c_str(), ysfDst.c_str());
 								m_conv.putYSFHeader();
 								m_usrpcs = ysfSrc;
 							}

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -505,10 +505,10 @@ int CUSRP2YSF::run()
  						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, dch);
 						break;
 					case 1:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_callsign.c_str());
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_usrpcs.c_str());
 						break;
 					case 2:
-						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_callsign.c_str());
+						ysfPayload.writeVDMode2Data(m_ysfFrame + 35U, (unsigned char*)m_usrpcs.c_str());
 						break;
 					case 5:
 						memset(dch, ' ', YSF_CALLSIGN_LENGTH/2);

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -260,7 +260,7 @@ int CUSRP2YSF::run()
 					m_usrpcs = (char *)(m_usrpFrame + 46);
 					if(!m_usrpFrames){	
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received as first frame callsign=%s", m_usrpcs);
+						LogMessage("USRP text info received as first frame callsign=%s", m_usrpcs.c_str());
 					}
 					m_usrpFrames++;
 				}

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -2,6 +2,7 @@
 *   Copyright (C) 2016,2017 by Jonathan Naylor G4KLX
 *   Copyright (C) 2018 by Andy Uribe CA6JAU
 * 	Copyright (C) 2020 by Doug McLain AD8DP
+*   Copyright (C) 2022 by Dave Behnke AC8ZD
 *
 *   This program is free software; you can redistribute it and/or modify
 *   it under the terms of the GNU General Public License as published by
@@ -33,7 +34,7 @@ const char* DEFAULT_INI_FILE = "/etc/USRP2YSF.ini";
 const char* HEADER1 = "This software is for use on amateur radio networks only,";
 const char* HEADER2 = "it is to be used for educational purposes only. Its use on";
 const char* HEADER3 = "commercial networks is strictly prohibited.";
-const char* HEADER4 = "Copyright(C) 2018 by AD8DP, CA6JAU, G4KLX and others";
+const char* HEADER4 = "Copyright(C) 2022 by AD8DP, CA6JAU, G4KLX, AC8ZD and others";
 
 #define M17CHARACTERS " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/."
 
@@ -55,6 +56,10 @@ void sig_handler(int signo)
 	}
 }
 
+//trim is necessary over usrp, especially USRP2M17, since people put wonky
+//calls in their radio like AC8ZD/DAVE. By default, callsigns coming in from YSF
+//are 10 characters and padded with spaces if callsign isn't that long.
+//to make it extra M17 friendly, we ensure the callsign is no longer than 8 characters.
 std::string trim_callsign(const std::string s) {
     const std::string ACCEPTABLECHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     size_t start = s.find_first_not_of(ACCEPTABLECHARS);

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -380,7 +380,7 @@ int CUSRP2YSF::run()
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
-				::memcpy(m_ysfFrame + 14U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = 0U; // Net frame counter
 
@@ -422,7 +422,7 @@ int CUSRP2YSF::run()
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
-				::memcpy(m_ysfFrame + 14U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = ysf_cnt; // Net frame counter
 
@@ -448,7 +448,7 @@ int CUSRP2YSF::run()
 				unsigned char csd1[20U], csd2[20U];
 				memset(csd1, '*', YSF_CALLSIGN_LENGTH/2);
  				memcpy(csd1 + YSF_CALLSIGN_LENGTH/2, m_conf.getYsfRadioID().c_str(), YSF_CALLSIGN_LENGTH/2);
-				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				memcpy(csd1 + YSF_CALLSIGN_LENGTH, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				memset(csd2, ' ', YSF_CALLSIGN_LENGTH + YSF_CALLSIGN_LENGTH);
 
 				CYSFPayload payload;
@@ -466,7 +466,7 @@ int CUSRP2YSF::run()
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
 				::memcpy(m_ysfFrame + 4U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
-				::memcpy(m_ysfFrame + 14U, m_callsign.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 
 				::memcpy(m_ysfFrame + 35U, YSF_SYNC_BYTES, YSF_SYNC_LENGTH_BYTES);

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -292,7 +292,7 @@ int CUSRP2YSF::run()
 				}
 				else if( (m_usrpFrame[20] == USRP_TYPE_VOICE) && (m_usrpFrame[15] == USRP_KEYUP_TRUE) ){
 					if(!m_usrpFrames){
-						m_usrpcs.clear();
+						//m_usrpcs.clear();
 						m_conv.putUSRPHeader();
 						LogMessage("USRP voice received as first frame");
 					}
@@ -406,7 +406,7 @@ int CUSRP2YSF::run()
 				ysf_cnt = 0U;
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
-				::memcpy(m_ysfFrame + 4U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 4U, m_ysfNetwork->getCallsign().c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = 0U; // Net frame counter
@@ -448,7 +448,7 @@ int CUSRP2YSF::run()
 			else if (ysfFrameType == TAG_EOT) {
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
-				::memcpy(m_ysfFrame + 4U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 4U, m_ysfNetwork->getCallsign().c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 				m_ysfFrame[34U] = ysf_cnt; // Net frame counter
@@ -492,7 +492,7 @@ int CUSRP2YSF::run()
 				unsigned int fn = (ysf_cnt - 1U) % (m_conf.getFICHFrameTotal() + 1);
 
 				::memcpy(m_ysfFrame + 0U, "YSFD", 4U);
-				::memcpy(m_ysfFrame + 4U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
+				::memcpy(m_ysfFrame + 4U, m_ysfNetwork->getCallsign().c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 14U, m_usrpcs.c_str(), YSF_CALLSIGN_LENGTH);
 				::memcpy(m_ysfFrame + 24U, "ALL       ", YSF_CALLSIGN_LENGTH);
 

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -55,6 +55,15 @@ void sig_handler(int signo)
 	}
 }
 
+std::string trim_callsign(const std::string s) {
+    const std::string ACCEPTABLECHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    size_t start = s.find_first_not_of(ACCEPTABLECHARS);
+    if (start > 8) {
+        start = 8;
+    }
+    return s.substr(0, start);
+}
+
 int main(int argc, char** argv)
 {
 	const char* iniFile = DEFAULT_INI_FILE;
@@ -257,10 +266,12 @@ int CUSRP2YSF::run()
 
 			if( (!memcmp(m_usrpFrame, "USRP", 4)) && len == 352) {
 				if( (m_usrpFrame[20] == USRP_TYPE_TEXT) && (m_usrpFrame[32] == TLV_TAG_SET_INFO) ){
-					m_usrpcs = (char *)(m_usrpFrame + 46);
-					if(!m_usrpFrames){	
+					std::string raw_usrpcs = (char *)(m_usrpFrame + 46);
+					m_usrpcs = trim_callsign(raw_usrpcs);
+					if (!m_usrpFrames)
+					{
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received as first frame callsign=%s", m_usrpcs.c_str());
+						LogMessage("USRP text info received as first frame raw_callsign=%s, trim_callsign=%s", raw_usrpcs.c_str(), m_usrpcs.c_str());
 					}
 					m_usrpFrames++;
 				}

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -260,7 +260,7 @@ int CUSRP2YSF::run()
 					m_usrpcs = (char *)(m_usrpFrame + 46);
 					if(!m_usrpFrames){	
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received as first frame");
+						LogMessage("USRP text info received as first frame callsign=%s", m_usrpcs);
 					}
 					m_usrpFrames++;
 				}

--- a/USRP2YSF/USRP2YSF.cpp
+++ b/USRP2YSF/USRP2YSF.cpp
@@ -69,6 +69,14 @@ std::string trim_callsign(const std::string s) {
     return s.substr(0, start);
 }
 
+//pad is necessary for the reverse back to ysf, the callsign needs to be 10 characters
+//spaces need to be placed if all 10 characters not used.
+void pad_callsign(std::string &str, const size_t num, const char paddingChar = ' ')
+{
+    if(num > str.size())
+        str.insert(str.size(), num - str.size(), paddingChar);
+}
+
 int main(int argc, char** argv)
 {
 	const char* iniFile = DEFAULT_INI_FILE;
@@ -272,10 +280,13 @@ int CUSRP2YSF::run()
 			if( (!memcmp(m_usrpFrame, "USRP", 4)) && len == 352) {
 				if( (m_usrpFrame[20] == USRP_TYPE_TEXT) && (m_usrpFrame[32] == TLV_TAG_SET_INFO) ){
 					m_usrpcs = (char *)(m_usrpFrame + 46);
+					// pad to 10 for ysf
+					pad_callsign(m_usrpcs, 10);
+
 					if (!m_usrpFrames)
 					{
 						m_conv.putUSRPHeader();
-						LogMessage("USRP text info received as first frame callsign=%s", m_usrpcs.c_str());
+						LogMessage("USRP text info received as first frame callsign=\"%s\" (%lu bytes)", m_usrpcs.c_str(), m_usrpcs.length());
 					}
 					m_usrpFrames++;
 				}

--- a/USRP2YSF/Version.h
+++ b/USRP2YSF/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20221022";
+const char* VERSION = "20221010";
 
 #endif

--- a/USRP2YSF/Version.h
+++ b/USRP2YSF/Version.h
@@ -20,6 +20,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20180923";
+const char* VERSION = "20221022";
 
 #endif


### PR DESCRIPTION
The callsigns were hardcoded when sending back and forth between M17 and YSF and USRP and YSF to the configured callsign that was configured in the config file.   This fix corrects that issue for both the USRP2YSF and M172YSF.   I have been testing both utilities on my M17 reflector bridged to a YSF reflector for a few days now and all is good.  Callsigns appear both on the YSF side and the M17 side as well as traversing USRP.   Please feel free to squash the commits into a single merge once accepted.  Thanks!

cc @nostar 