### PR TITLE
Update Conf.h - Missing include

### DIFF
--- a/USRP2P25/Conf.h
+++ b/USRP2P25/Conf.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class CConf
 {


### PR DESCRIPTION
USRP2P25 was failing compile on Ubuntu 24.04LTS. This fixes it.